### PR TITLE
Enable anchors in headings {#anchor} - vitepress

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,13 @@ import { sharedData } from "./src/shared_data.js";
 //const path = require("path");
 import { program } from "commander";
 //const { program } = require("commander");
-import { logFunction, logToFile, isMarkdown, isHTML, isImage } from "./src/helpers.js";
+import {
+  logFunction,
+  logToFile,
+  isMarkdown,
+  isHTML,
+  isImage,
+} from "./src/helpers.js";
 
 import { outputErrors } from "./src/output_errors.js";
 
@@ -21,7 +27,6 @@ import {
 } from "./src/process_orphans.js";
 import { checkImageOrphansGlobal } from "./src/process_image_orphans.js";
 import { filterErrors, filterIgnoreErrors } from "./src/filters.js";
-
 
 program
   .option(
@@ -73,7 +78,12 @@ program
     "Interactively add errors to the ignore list at _link_checker_sc/ignore_errors.json",
     false
   )
-
+  .option(
+    //This doesn't work. Dunno why - does for other cases!
+    "-c, --anchor_in_heading [value]",
+    "Detect anchors in heading such as: # Heading {#anchor}",
+    true
+  )
   .parse(process.argv);
 
 // TODO PX4 special parsing - errors or pages we exclude by default.
@@ -184,7 +194,6 @@ const processDirectory = async (dir) => {
   }
   return results;
 };
-
 
 //main function, after options et have been set up.
 (async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown_link_checker_sc",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "description": "Markdown Link Checker",
   "main": "index.js",
   "scripts": {

--- a/src/process_markdown.js
+++ b/src/process_markdown.js
@@ -41,8 +41,29 @@ const processMarkdown = (contents, page) => {
 
       // match headings
       const matches = line.match(/^#+\s+(.+)$/);
+
       if (matches) {
-        headings.push(matches[1]);
+        let heading = matches[1];
+
+        //console.log(sharedData.options.anchor_in_heading);
+
+        if (sharedData.options.anchor_in_heading) {
+          // True by default - catch anchors in headings
+
+          // Define the regex pattern to match the heading and anchor
+          // If it exists, overwrite heading and also push the anchor
+          const pattern = /(.*?)\{#(.*?)\}\s*?/;
+          const anchormatches = heading.match(pattern);
+          if (anchormatches) {
+            //console.log(anchormatches);
+            heading = anchormatches[1].trim();
+            //console.log(heading);
+            htmlAnchors.push(anchormatches[2]);
+            //console.log(anchormatches[2]);
+          }
+        }
+
+        headings.push(heading);
       }
       // TODO - have to slugify later.
 
@@ -60,7 +81,6 @@ const processMarkdown = (contents, page) => {
       // This gets a reference links
     }
 
-
     const referenceLinkInfo = processReferenceLinks(contents, page);
     urlLinks.push(...referenceLinkInfo.urlLinks);
     urlLocalLinks.push(...referenceLinkInfo.urlLocalLinks);
@@ -68,7 +88,7 @@ const processMarkdown = (contents, page) => {
     relativeLinks.push(...referenceLinkInfo.relativeLinks);
     relativeImageLinks.push(...referenceLinkInfo.relativeImageLinks);
     errors.push(...referenceLinkInfo.errors);
-    
+
     //errors: errors, //TODO need to also pass referenceLinkInfo.errors
 
     // Match html tags that have an id element
@@ -105,8 +125,6 @@ const processMarkdown = (contents, page) => {
     errors,
   };
 };
-
-
 
 // Processes line, taking arrays of different link types.
 // Update the incoming values and return

--- a/src/slugify.js
+++ b/src/slugify.js
@@ -1,6 +1,7 @@
 // Returns slug for a string (markdown heading) using Vuepress algorithm.
 // Algorithm from chatgpt - needs testing.
 function slugifyVuepress(str) {
+  //console.log(`DEBUG: SLUG: str: ${str}`);
   const slug = str
     .toLowerCase()
     .replace(/\/+/g, "-") // replace / with hyphens


### PR DESCRIPTION
This detects anchors in the heading, which is supported in legacy gitbook and also vitepress. Such as 

```
# Heading {#some-anchor}
```

Note, there is an option but it is always enabled (bug)