### PR TITLE
Fix interactive adding exclusions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ node index.js -r ~/github/PX4/PX4-Autopilot/ -d docs -e en -i assets -x true
 | `-t` | TOC/summary file path (inferred if not set) |
 | `-u` | Site base URL (e.g. `docs.px4.io`). Without `-u`, absolute links to your site are treated as external URLs. With `-u`, they are flagged as `UrlToLocalSite` errors ("should this be relative?") |
 | `-m false` | Disable markdown fallback for `.html` links (try `.md` if `.html` not found) |
-| `-p true` | Interactive mode — build ignore list by answering prompts |
+| `--interactive` | Interactive mode — build ignore list by answering prompts |
 | `-o false` | Disable log file output |
 
 ## Output
@@ -68,12 +68,12 @@ State is managed in `index.js` via `sharedData` from `src/shared_data.js`. All p
 ## Ignore Files
 
 - `<docsroot>/_link_checker_sc/ignorefile.json` — array of files to skip parsing (paths relative to docsroot)
-- `<repo>/_link_checker_sc/ignore_errors.json` — specific errors to suppress (built interactively with `-p true`)
+- `<repo>/_link_checker_sc/ignore_errors.json` — specific errors to suppress (built interactively with `--interactive`)
 
 Entries in `ignore_errors.json` may have an optional `expiry` field (`YYYY-MM-DD`). When an entry expires:
 - It is **kept** in the file with `expired: true` added (not deleted), so the history is visible.
 - The error re-appears in output, annotated with `[Previously ignored until <date>: "<reason>"]`.
-- In interactive mode (`-p true`), the previous reason is offered as the default when re-ignoring.
+- In interactive mode (`--interactive`), the previous reason is offered as the default when re-ignoring.
 - To renew: remove or update `expiry` and remove `expired: true`. To clean up: delete the entry manually.
 
 ## Source Files

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Options:
   -u, --site_url [value]              Site base url in form dev.example.com (used to catch absolute urls to local
                                       files)
   -o, --logtofile [value]             Output logs to file (default: true)
-  -p, --interactive [value]           Interactively add errors to the ignore list at
+  --interactive [value]               Interactively add errors to the ignore list at
                                       <repo>/_link_checker_sc/ignore_errors.json (default: false)
   --anchor_in_heading [value]         Detect anchors in heading such as: # Heading {#anchor} (default: true)
   -x, --externallink [value]          Output logs to file (default: false)

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ program
   )
   .option("-o, --logtofile [value]", "Output logs to file", true)
   .option(
-    "-p, --interactive [value]",
+    "--interactive [value]",
     "Interactively add errors to the ignore list at <repo>/_link_checker_sc/ignore_errors.json",
     false
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown_link_checker_sc",
-  "version": "0.0.141",
+  "version": "0.0.144",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown_link_checker_sc",
-      "version": "0.0.141",
+      "version": "0.0.144",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "markdown_link_checker_sc",
-  "version": "0.0.143",
+  "version": "0.0.144",
   "description": "Markdown Link Checker",
   "main": "index.js",
   "scripts": {
-    "test": "node --test --test-reporter spec tests/unit/*.test.js tests/integration/*.test.js"
+    "test": "node --experimental-test-module-mocks --test --test-reporter spec tests/unit/*.test.js tests/integration/*.test.js"
   },
   "type": "module",
   "keywords": [

--- a/src/output_errors.js
+++ b/src/output_errors.js
@@ -99,10 +99,14 @@ function outputErrors(results, options) {
   // But only if iterative update in progress
   if (options.interactive) {
     const filePath = path.join(dirPath, "ignore_errors.json");
-    fs.writeFileSync(
-      filePath,
-      JSON.stringify(ignoreErrors, null, 2)
-    );
+    let existingIgnoreErrors = [];
+    try {
+      existingIgnoreErrors = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    } catch {
+      // File doesn't exist yet — start fresh
+    }
+    const merged = [...existingIgnoreErrors, ...ignoreErrors];
+    fs.writeFileSync(filePath, JSON.stringify(merged, null, 2));
   }
 }
 

--- a/tests/unit/outputErrors.test.js
+++ b/tests/unit/outputErrors.test.js
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the interactive file-write behaviour of outputErrors().
+ *
+ * Key invariant: calling outputErrors() in interactive mode must preserve any
+ * entries already in ignore_errors.json and merge new entries on top — never
+ * overwrite the file with only the entries added in the current session.
+ */
+
+import { test, describe, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+// ─── Prompt mock ─────────────────────────────────────────────────────────────
+// Must be installed before output_errors.js is imported so that the module-
+// level `const prompt = promptSync()` picks up the mock implementation.
+
+let promptQueue = [];
+
+mock.module("prompt-sync", {
+  defaultExport: () => {
+    // Returns a promptSync "instance" — a callable function.
+    return (_question, defaultVal) => {
+      if (promptQueue.length > 0) return promptQueue.shift();
+      return defaultVal ?? "N";
+    };
+  },
+});
+
+const { outputErrors } = await import("../../src/output_errors.js");
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTempDocsroot(ignoreEntries) {
+  const docsroot = fs.mkdtempSync(path.join(os.tmpdir(), "lc-out-test-"));
+  const dir = path.join(docsroot, "_link_checker_sc");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "ignore_errors.json"),
+    JSON.stringify(ignoreEntries, null, 2)
+  );
+  return docsroot;
+}
+
+function readIgnoreFile(docsroot) {
+  const filePath = path.join(docsroot, "_link_checker_sc", "ignore_errors.json");
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function makeResult(docsroot, { type, fileRelativeToRoot, linkUrl } = {}) {
+  const file = path.join(docsroot, fileRelativeToRoot);
+  return {
+    type,
+    file,
+    fileRelativeToRoot,
+    link: linkUrl ? { url: linkUrl, text: "" } : undefined,
+    output() {
+      // no-op: suppress console output during tests
+    },
+  };
+}
+
+function makeOpts(docsroot) {
+  return {
+    docsroot,
+    log: [],
+    logtofile: false,
+    interactive: true,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("outputErrors — interactive file-write behaviour", () => {
+  test("existing entries are preserved when new ones are added", () => {
+    const existing = [
+      {
+        type: "ExternalLinkWarning",
+        fileRelativeToRoot: "en/old-page.md",
+        link: { url: "https://old.example.com/", text: "" },
+        hideReason: "pre-existing entry",
+      },
+    ];
+    const docsroot = makeTempDocsroot(existing);
+
+    const results = [
+      makeResult(docsroot, {
+        type: "ExternalLinkWarning",
+        fileRelativeToRoot: "en/new-page.md",
+        linkUrl: "https://new.example.com/",
+      }),
+    ];
+
+    // Simulate: user answers "Y" then provides a reason.
+    promptQueue = ["Y", "new reason"];
+
+    outputErrors(results, makeOpts(docsroot));
+
+    const written = readIgnoreFile(docsroot);
+    assert.strictEqual(written.length, 2, "Both old and new entries should be in the file");
+    assert.ok(
+      written.some((e) => e.link?.url === "https://old.example.com/"),
+      "Pre-existing entry should be preserved"
+    );
+    assert.ok(
+      written.some((e) => e.link?.url === "https://new.example.com/"),
+      "Newly added entry should be present"
+    );
+  });
+
+  test("existing entries are preserved when user says N to all errors", () => {
+    const existing = [
+      {
+        type: "ExternalLinkWarning",
+        fileRelativeToRoot: "en/old-page.md",
+        link: { url: "https://old.example.com/", text: "" },
+        hideReason: "pre-existing entry",
+      },
+    ];
+    const docsroot = makeTempDocsroot(existing);
+
+    const results = [
+      makeResult(docsroot, {
+        type: "ExternalLinkWarning",
+        fileRelativeToRoot: "en/some-page.md",
+        linkUrl: "https://some.example.com/",
+      }),
+    ];
+
+    // Simulate: user answers "N" — no new entries should be added.
+    promptQueue = ["N"];
+
+    outputErrors(results, makeOpts(docsroot));
+
+    const written = readIgnoreFile(docsroot);
+    assert.strictEqual(written.length, 1, "File must not be cleared when user adds nothing");
+    assert.strictEqual(
+      written[0].link.url,
+      "https://old.example.com/",
+      "Original entry should be unchanged"
+    );
+  });
+});


### PR DESCRIPTION
This fixes a bug in the code that added items to the exclusions list - which meant that it just deleted the list each time. Also changes `-p` option to `--interactive` only.